### PR TITLE
netfilter and bpf syscall support

### DIFF
--- a/conform_config.sh
+++ b/conform_config.sh
@@ -56,3 +56,103 @@ set_kernel_config ZBUD y
 set_kernel_config Z3FOLD y
 set_kernel_config ZSMALLOC y
 set_kernel_config PGTABLE_MAPPING y
+
+#https://groups.google.com/forum/#!topic/linux.gentoo.user/_2aSc_ztGpA
+#https://github.com/torvalds/linux/blob/master/init/Kconfig#L848
+#Enables BPF syscall for systemd-journald firewalling
+ 
+set_kernel_config CONFIG_BPF_SYSCALL y
+set_kernel_config CONFIG_CGROUP_BPF y
+
+#See https://github.com/raspberrypi/linux/issues/2177#issuecomment-354647406
+# Netfilter kernel support
+# xtables
+set_kernel_config NETFILTER_XTABLES m
+# Netfilter nf_tables support
+set_kernel_config NF_TABLES m
+set_kernel_config CONFIG_NETFILTER_XTABLES m
+set_kernel_config CONFIG_NF_TABLES_BRIDGE m
+set_kernel_config CONFIG_NF_NAT_SIP m
+set_kernel_config CONFIG_NF_NAT_TFTP m
+set_kernel_config CONFIG_NF_NAT_REDIRECT m
+set_kernel_config CONFIG_NF_TABLES_INET m
+set_kernel_config CONFIG_NF_TABLES_NETDEV m
+set_kernel_config CONFIG_NF_TABLES_ARP m
+set_kernel_config CONFIG_NF_DUP_IPV4 m
+set_kernel_config CONFIG_NF_LOG_IPV4 m
+set_kernel_config CONFIG_NF_REJECT_IPV4 m
+set_kernel_config CONFIG_NF_NAT_IPV4 m
+set_kernel_config CONFIG_NF_DUP_NETDEV m
+set_kernel_config CONFIG_NF_DEFRAG_IPV4 m
+set_kernel_config CONFIG_NF_CONNTRACK_IPV4 m
+set_kernel_config CONFIG_NF_TABLES_IPV4 m
+set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV4 m
+set_kernel_config CONFIG_NF_NAT_SNMP_BASIC m
+set_kernel_config CONFIG_NF_NAT_PROTO_GRE m
+set_kernel_config CONFIG_NF_NAT_PPTP m
+set_kernel_config CONFIG_NF_DEFRAG_IPV6 m
+set_kernel_config CONFIG_NF_CONNTRACK_IPV6 m
+set_kernel_config CONFIG_NF_TABLES_IPV6 m
+set_kernel_config CONFIG_NF_DUP_IPV6 m
+set_kernel_config CONFIG_NF_REJECT_IPV6 m
+set_kernel_config CONFIG_NF_LOG_IPV6 m
+set_kernel_config CONFIG_NF_NAT_IPV6 m
+set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV6 m
+set_kernel_config CONFIG_NFT_EXTHDR m
+set_kernel_config CONFIG_NFT_META m
+set_kernel_config CONFIG_NFT_NUMGEN m
+set_kernel_config CONFIG_NFT_CT m
+set_kernel_config CONFIG_NFT_SET_RBTREE m
+set_kernel_config CONFIG_NFT_SET_HASH m
+set_kernel_config CONFIG_NFT_COUNTER m
+set_kernel_config CONFIG_NFT_LOG m
+set_kernel_config CONFIG_NFT_LIMIT m
+set_kernel_config CONFIG_NFT_MASQ m
+set_kernel_config CONFIG_NFT_REDIR m
+set_kernel_config CONFIG_NFT_NAT m
+set_kernel_config CONFIG_NFT_QUEUE m
+set_kernel_config CONFIG_NFT_QUOTA m
+set_kernel_config CONFIG_NFT_REJECT m
+set_kernel_config CONFIG_NFT_REJECT_INET m
+set_kernel_config CONFIG_NFT_COMPAT m
+set_kernel_config CONFIG_NFT_HASH m
+set_kernel_config CONFIG_NFT_DUP_NETDEV m
+set_kernel_config CONFIG_NFT_FWD_NETDEV m
+set_kernel_config CONFIG_NFT_CHAIN_ROUTE_IPV4 m
+set_kernel_config CONFIG_NFT_REJECT_IPV4 m
+set_kernel_config CONFIG_NFT_DUP_IPV4 m
+set_kernel_config CONFIG_NFT_CHAIN_NAT_IPV4 m
+set_kernel_config CONFIG_NFT_MASQ_IPV4 m
+set_kernel_config CONFIG_NFT_REDIR_IPV4 m
+set_kernel_config CONFIG_NFT_CHAIN_ROUTE_IPV6 m
+set_kernel_config CONFIG_NFT_REJECT_IPV6 m
+set_kernel_config CONFIG_NFT_DUP_IPV6 m
+set_kernel_config CONFIG_NFT_CHAIN_NAT_IPV6 m
+set_kernel_config CONFIG_NFT_MASQ_IPV6 m
+set_kernel_config CONFIG_NFT_REDIR_IPV6 m
+set_kernel_config CONFIG_NFT_BRIDGE_META m
+set_kernel_config CONFIG_NFT_BRIDGE_REJECT m
+set_kernel_config CONFIG_IP_SET_BITMAP_IPMAC m
+set_kernel_config CONFIG_IP_SET_BITMAP_PORT m
+set_kernel_config CONFIG_IP_SET_HASH_IP m
+set_kernel_config CONFIG_IP_SET_HASH_IPMARK m
+set_kernel_config CONFIG_IP_SET_HASH_IPPORT m
+set_kernel_config CONFIG_IP_SET_HASH_IPPORTIP m
+set_kernel_config CONFIG_IP_SET_HASH_IPPORTNET m
+set_kernel_config CONFIG_IP_SET_HASH_MAC m
+set_kernel_config CONFIG_IP_SET_HASH_NETPORTNET m
+set_kernel_config CONFIG_IP_SET_HASH_NET m
+set_kernel_config CONFIG_IP_SET_HASH_NETNET m
+set_kernel_config CONFIG_IP_SET_HASH_NETPORT m
+set_kernel_config CONFIG_IP_SET_HASH_NETIFACE m
+set_kernel_config CONFIG_IP_SET_LIST_SET m
+set_kernel_config CONFIG_IP6_NF_IPTABLES m
+set_kernel_config CONFIG_IP6_NF_MATCH_AH m
+set_kernel_config CONFIG_IP6_NF_MATCH_EUI64 m
+set_kernel_config CONFIG_IP6_NF_NAT m
+set_kernel_config CONFIG_IP6_NF_TARGET_MASQUERADE m
+set_kernel_config CONFIG_IP6_NF_TARGET_NPT m
+set_kernel_config CONFIG_NF_LOG_BRIDGE m
+set_kernel_config CONFIG_BRIDGE_NF_EBTABLES m
+set_kernel_config CONFIG_BRIDGE_EBT_BROUTE m
+set_kernel_config CONFIG_BRIDGE_EBT_T_FILTER m 


### PR DESCRIPTION
Hi @sakaki,

nice work you've done with kernel,overlay and gentoo64bit! Maybe the following pull/info is usefull for your project:

- Enabling BPF_SYSCALL should fix an error with systemd (which wants BPF_SYSCALL for firewalling)
see [here](https://groups.google.com/forum/#!topic/linux.gentoo.user/_2aSc_ztGpA) and [here](https://github.com/torvalds/linux/blob/master/init/Kconfig#L848)
- nftables is the default iptables alternative in debian distro. So Kernel should be able to provide that interface too. see [here](https://github.com/raspberrypi/linux/issues/2177#issuecomment-354647406)
